### PR TITLE
displays one decimal in percentages

### DIFF
--- a/src/components/analysis/widget-templates/estimates/config.js
+++ b/src/components/analysis/widget-templates/estimates/config.js
@@ -6,8 +6,8 @@ import WidgetTooltip from 'components/analysis/widget-tooltip';
 
 // Utils
 import { format } from 'd3-format';
-const percentageFormat = format(',.0%');
 const numberFormat = format(',.0f');
+const percentageFormat = (value) => format('~')(format(',.1f')(value));
 
 
 const getMetadata = (data) => data.map(d => d.name)
@@ -136,7 +136,7 @@ export const CONFIG = {
                 payload={payload}
                 title={`Populations in ${region}`}
                 settings={payload.map(bar => {
-                  const percentage = bar.payload.total_populations === 0 ? '' : `  (${percentageFormat(bar.value / bar.payload.total_populations)})`;
+                  const percentage = bar.payload.total_populations === 0 ? '' : `  (${percentageFormat((bar.value / bar.payload.total_populations) * 100)}%)`;
                   return {
                     label: bar.dataKey,
                     color: bar.color,

--- a/src/components/analysis/widget-templates/families/config.js
+++ b/src/components/analysis/widget-templates/families/config.js
@@ -7,7 +7,7 @@ import WidgetTooltip from 'components/analysis/widget-tooltip';
 // Utils
 import { format } from 'd3-format';
 const numberFormat = format(',.0f');
-const percentageFormat = format(',.2f');
+const percentageFormat = (value) => format('~')(format(',.1f')(value));
 
 const getBars = data => data.reduce((acc, d) => {
 

--- a/src/components/analysis/widget-templates/populations/config.js
+++ b/src/components/analysis/widget-templates/populations/config.js
@@ -75,7 +75,7 @@ export const CONFIG = {
               }}
               type="column"
               payload={payload}
-              title='Number of opulations'
+              title='Number of populations'
               settings={payload.map(bar => {
                 return {
                   key: bar.dataKey, format: value => numberFormat(value)


### PR DESCRIPTION
Analyze page: show all percentages with 1 decimal (trimmed to zero if needed)

![image](https://user-images.githubusercontent.com/999124/100731447-ac7a3580-33cb-11eb-9117-f1934e5a0783.png)
![image](https://user-images.githubusercontent.com/999124/100731460-b2701680-33cb-11eb-8871-6249f0a10237.png)


## Testing instructions

Go to Analyze, check tooltips.

## Pivotal Tracker

Link to the task(s), if any
