### PR TITLE
Fix #141

### DIFF
--- a/src/services/population.js
+++ b/src/services/population.js
@@ -89,7 +89,7 @@ export const fetchPopulations = (specieid) => {
     'startyear', population_trend_startyear,
     'endyear', population_trend_endyear,
     'notes', population_trend_notes,
-    'references', reference
+    'references', population_trend_reference
   ))
   as trends,
   jsonb_agg(distinct jsonb_build_object(

--- a/src/services/view
+++ b/src/services/view
@@ -5,9 +5,9 @@ DROP VIEW IF EXISTS population_all_data;
 CREATE VIEW population_all_data AS
 SELECT
   jsonb_agg((select row_to_json(_)
-	from (select ps.*, refs.*) as _)::jsonb) as reference,
+	from (select ps.*, refs.*) as _)::jsonb) as population_size_reference,
   jsonb_agg((select row_to_json(_)
-                  from (select pt.*, reft.*) as _)::jsonb) as population_size_reference,
+  from (select pt.*, reft.*) as _)::jsonb) as population_trend_reference,
   ps.populationsize_id,
   p.publication_id,
   n.id as population_id,


### PR DESCRIPTION
Fix for the mixed up size and trend references. Clarified the SQL code for the view on Carto.

**PLEASE FOLLOW THESE STEPS WHEN MERGING**

- Rename the Carto view from "population_all_data" to "pop_all_data_backup" to have a backup when things go wrong
- Recreate the Carto view "population_all_data" using the SQL in src\services\view when deploying this code
- Because the Carto backend has now changed, both develop and master braches will need to be updated with this PR so that both staging and production Heroku environments are fixed.

